### PR TITLE
Fix leaked .header style on table headers and add unknown-path fallback

### DIFF
--- a/website/src/components/HutListPage.vue
+++ b/website/src/components/HutListPage.vue
@@ -278,6 +278,17 @@
    color: var(--text-muted) !important;
 }
 
+/* The library renders each column header in a generic `.header` div, which
+   collides with the app-wide `.header` style in App.vue (white background,
+   padding, green underline). Neutralize the leak so header cells keep the
+   table's own `--surface-muted` background. */
+:deep(.vue3-easy-data-table__header th .header) {
+   background: transparent;
+   padding: 0;
+   margin: 0;
+   border-bottom: none;
+}
+
 :deep(.vue3-easy-data-table__body tr:nth-child(even) td) {
    background-color: var(--surface-muted) !important;
 }

--- a/website/src/router/index.js
+++ b/website/src/router/index.js
@@ -29,5 +29,10 @@ export default createRouter({
          name: "infoPage",
          component: () => import("../components/InfoPage.vue"),
       },
+      {
+         // Any unknown path falls back to the root (map) instead of a blank page.
+         path: "/:pathMatch(.*)*",
+         redirect: "/",
+      },
    ],
 });


### PR DESCRIPTION
The vue3-easy-data-table library renders each column header in a generic .header div, which collided with App.vue's app-wide .header rule (white background, padding, green underline), giving the hut list header cells a white box that didn't match the intended --surface-muted background. Neutralize the leaked styles within the table header.

Also add a catch-all route so any unknown path (e.g. /huts) redirects to the root (map) instead of rendering a blank page.


Copilot-Session: 6226f9e9-41fc-45f3-ab1e-fb97bdeea3d5